### PR TITLE
chore: configure Dependabot to use Conventional Commits

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,10 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    commit-message:
+      prefix: "chore(deps)"
+      prefix-development: "chore(deps-dev)"
+      include: "scope"
     groups:
       dev-dependencies:
         dependency-type: development
@@ -18,3 +22,6 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    commit-message:
+      prefix: "chore(ci)"
+      include: "scope"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,8 +5,8 @@ updates:
     schedule:
       interval: weekly
     commit-message:
-      prefix: "chore(deps)"
-      prefix-development: "chore(deps-dev)"
+      prefix: "chore"
+      prefix-development: "chore"
       include: "scope"
     groups:
       dev-dependencies:
@@ -23,5 +23,5 @@ updates:
     schedule:
       interval: weekly
     commit-message:
-      prefix: "chore(ci)"
+      prefix: "chore"
       include: "scope"


### PR DESCRIPTION
Adds `commit-message` configuration to both Dependabot ecosystems so generated PR titles and commits follow Conventional Commits format, matching the project's PR title convention enforced by CI.

- npm updates: `chore(deps): ...` for production, `chore(deps-dev): ...` for dev dependencies
- GitHub Actions updates: `chore(ci): ...`

---
*Created by Claude Sonnet 4.6*