### PR TITLE
fix: remove redundant type assertions in getAuthErrorMessage

### DIFF
--- a/src/lib/auth-errors.ts
+++ b/src/lib/auth-errors.ts
@@ -14,10 +14,9 @@ export function getAuthErrorMessage(error: unknown): string {
     typeof error === "object" &&
     error !== null &&
     "code" in error &&
-    typeof (error as { code: unknown }).code === "string"
+    typeof error.code === "string"
   ) {
-    const code = (error as { code: string }).code;
-    return FIREBASE_ERROR_MAP[code] ?? AUTH_COPY.errors.generic;
+    return FIREBASE_ERROR_MAP[error.code] ?? AUTH_COPY.errors.generic;
   }
   return AUTH_COPY.errors.generic;
 }


### PR DESCRIPTION
After `"code" in error`, TypeScript narrows `error` to `{ code: unknown }`, making the `as { code: unknown }` cast on the typeof check redundant. After the typeof guard, `error.code` is further narrowed to `string`, so the second cast and intermediate `code` variable are also unnecessary.

This was surfaced as a lint failure by `typescript-eslint` 8.59.0's improved `no-unnecessary-type-assertion` detection (Dependabot PR #70).

---
*Created by Claude Sonnet 4.6*