### PR TITLE
chore: sync deploy config validation and secret scanning from template

### DIFF
--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -1,0 +1,30 @@
+name: Secret Scan
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  gitleaks:
+    name: Detect secrets
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  validate-config:
+    name: Validate deployment config
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/setup
+      - run: node scripts/validate-config.mjs

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,45 @@
+# gitleaks configuration
+# https://github.com/gitleaks/gitleaks
+#
+# Extends the default ruleset with project-specific patterns and allowlists
+# known false positives (e.g. example/placeholder values in documentation).
+
+title = "trip-split"
+
+[extend]
+useDefault = true
+
+[allowlist]
+description = "Known safe patterns — placeholder values in documentation and config examples"
+regexes = [
+  # Placeholder values used in .env.example and documentation
+  '''your-project-id''',
+  '''your-project''',
+  '''firebase-adminsdk-xxx''',
+  # Example/truncated keys in ARCHITECTURE.md and README
+  '''xxx@o\w+\.ingest\.sentry\.io''',
+  # The .env.example file itself — it contains only placeholder values
+]
+paths = [
+  ".env.example",
+]
+
+# Project-specific rules for secrets not covered by the default ruleset
+
+[[rules]]
+id = "firebase-private-key"
+description = "Firebase service account private key"
+regex = '''-----BEGIN (RSA )?PRIVATE KEY-----'''
+tags = ["firebase", "key"]
+
+[[rules]]
+id = "firebase-admin-json"
+description = "Firebase service account JSON blob"
+regex = '''"private_key_id"\s*:\s*"[a-f0-9]{40}"'''
+tags = ["firebase", "key"]
+
+[[rules]]
+id = "vercel-token"
+description = "Vercel API token"
+regex = '''(?i)vercel[_-]?token['":\s=]+[A-Za-z0-9]{24,}'''
+tags = ["vercel"]

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,2 +1,3 @@
 #!/usr/bin/env sh
 pnpm exec lint-staged
+pnpm run secrets-check

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,3 +1,4 @@
 #!/usr/bin/env sh
+set -e
 pnpm exec lint-staged
 pnpm run secrets-check

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,19 @@ pnpm test             # Run tests with Vitest
 pnpm typecheck        # Type check
 pnpm storybook        # Start Storybook dev server (port 6006)
 pnpm build-storybook  # Build static Storybook
+pnpm env:pull         # Pull .env.local from Vercel (staging)
+pnpm env:validate     # Validate deployment config files against schema
+pnpm secrets-check    # Run secret scan (deployment config validation + gitleaks)
 ```
+
+## Deployment Config
+
+Public (non-sensitive) environment variables are committed to `deployment/{env}.yml` and validated against `deployment/schema.yml`. This keeps the diff reviewable and prevents accidental secret exposure.
+
+- **Never** put secrets, private keys, auth tokens, or DSNs in `deployment/` files — the pre-commit hook and CI will reject them.
+- To populate values for a new environment, run `scripts/update-config.sh --env=staging --firebase-config=/path/to/config.json`.
+- Sensitive variables (Firebase private key, Sentry auth token) are managed directly in Vercel and never committed. Run `pnpm env:pull` to get a local `.env.local`.
+- To rotate credentials: `scripts/rotate-keys.sh --env=staging` (or `--env=production`). The script creates new credentials, updates Vercel, waits for a healthy deployment, then decommissions the old ones.
 
 ## Project Overview
 
@@ -52,7 +64,7 @@ src/
 ## File Organization
 
 - **Source files**: Keep under ~200 lines (split at ~240). Large files should be split by logical concern.
-- **Test files**: Keep under ~300 lines (split at ~360). Use `.spec.ts` / `.spec.tsx` extension. When splitting, organize into a `{module}-tests/` directory with domain-specific files.
+- **Test files**: Keep under ~300 lines (split at ~360). Use `.spec.ts` / `.spec.tsx` extension (not `.test.ts`). When splitting, organize into a `{module}-tests/` directory with domain-specific files.
 - **Components**: A component file contains its primary component and props interface. A sub-component may be co-located in the same file if it owns no hooks, state, effects, or context, and is used only by the parent component in that file. A sub-component must be in its own file when any of these are true: it owns hooks, state, effects, or context; it is referenced from multiple parents; or it is substantial enough to warrant its own stories or tests. All component props must be defined as an explicitly named interface (e.g., `interface TripCardProps`), never inline in the function signature.
 - **Type files**: Convert large type files into barrel-exported directories with one file per logical domain.
 - **Utility files**: Split by the type of operation or domain they serve.
@@ -65,9 +77,9 @@ src/
 - **Favor type inference.** Explicit generic type arguments (e.g., `someFn<Foo>(...)`) are a code smell when TypeScript can infer them.
 - **No spurious variables.** Do not assign a value to a variable only to immediately return it on the next line — return the expression directly instead.
 - **No IIFEs.** Do not use immediately-invoked function expressions. Extract the logic into a named helper function or compute the value with a plain expression instead.
-- **No function-style imports.** Do not use inline `import("…").Type` syntax in type annotations. Use module-level `import type { … } from "…"` statements at the top of the file.
-- **No unnecessary helpers.** Do not extract logic into a helper function unless it separates significant logic or belongs in a different module.
-- **Prefer enums over string literal unions** for any domain concept with two or more named states (e.g., use `enum SplitType { Equal = "equal", Itemized = "itemized" }` rather than `"equal" | "itemized"`). String enum values must match existing serialized literals so Firebase data round-trips without migration.
+- **No function-style imports.** Do not use inline `import("…").Type` syntax in type annotations. Use module-level `import type { … } from "…"` statements at the top of the file. Exception: dynamic `await import(…)` for Sentry instrumentation (required by the Next.js Sentry integration) is acceptable.
+- **No unnecessary helpers.** Do not extract logic into a helper function unless it separates significant logic or belongs in a different module. Three similar lines is better than a premature abstraction.
+- **Prefer enums over string literal unions** for any domain concept with two or more named states (e.g., use `enum SplitType { Equal = "equal", Itemized = "itemized" }` rather than `"equal" | "itemized"`). String enum values must match existing serialized literals so Firebase data round-trips without migration. When a module exports multiple enums, barrel-export them from an `index.ts` so callers use a single import path.
 - **Enums and constant objects** should be kept in alphabetical order to minimize merge conflicts.
 - Format currency using the `formatCurrency` utility from `@/lib/format`, never manually.
 

--- a/deployment/environments.yml
+++ b/deployment/environments.yml
@@ -1,0 +1,16 @@
+# Declares which environments are active for this project.
+#
+# Scripts will error unless all listed environments have a corresponding
+# deployment/{environment}.yml config file. This prevents accidental
+# misconfiguration where a repo expects separate staging and production
+# environments but is operating with only one.
+#
+# Set single_environment: true ONLY when this project intentionally uses
+# a single environment (e.g. ephemeral data with no meaningful staging/prod
+# distinction). The default is false — both environments must be present.
+
+environments:
+  - staging
+  - production
+
+single_environment: false

--- a/deployment/production.yml
+++ b/deployment/production.yml
@@ -1,0 +1,29 @@
+# Public environment variables for the production environment.
+#
+# Only non-sensitive variables belong here. All keys are validated against
+# deployment/schema.yml — sensitive variables (private keys, auth tokens, DSNs)
+# will be rejected by the pre-commit hook and CI.
+#
+# Sensitive variables are managed directly in Vercel and are never committed.
+# Run `pnpm env:pull` to generate a local .env.local from Vercel's stored values.
+#
+# To update these values and sync them to Vercel: scripts/update-config.sh --env=production
+
+environment: production
+
+variables:
+  # Firebase Client SDK — safe to expose; access control is enforced by Firebase security rules
+  NEXT_PUBLIC_FIREBASE_API_KEY: ""
+  NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN: ""
+  NEXT_PUBLIC_FIREBASE_PROJECT_ID: ""
+  NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET: ""
+  NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID: ""
+  NEXT_PUBLIC_FIREBASE_APP_ID: ""
+  NEXT_PUBLIC_FIREBASE_DATABASE_URL: ""
+
+  # Firebase Admin SDK — project identifier only, not a credential
+  FIREBASE_PROJECT_ID: ""
+
+  # Sentry — slugs only, not credentials
+  SENTRY_ORG: ""
+  SENTRY_PROJECT: ""

--- a/deployment/schema.yml
+++ b/deployment/schema.yml
@@ -1,0 +1,35 @@
+# Schema for public environment config files (deployment/staging.yml, deployment/production.yml).
+#
+# All keys in those files must match at least one allowed_pattern OR appear in allowed_keys.
+# Keys matching any denied_pattern are rejected even if they match an allowed_pattern.
+#
+# To add a new public variable (e.g. NEXT_PUBLIC_FIREBASE_DATABASE_URL or
+# NEXT_PUBLIC_DEBUG_MODE): add it to the config file — no schema change needed,
+# because NEXT_PUBLIC_* is already an allowed pattern.
+#
+# To add a server-side non-sensitive variable (e.g. FIREBASE_PROJECT_ID):
+# add it to allowed_keys below with a comment explaining why it is safe to commit.
+
+# Keys matching these glob patterns are allowed without explicit listing.
+# NEXT_PUBLIC_* variables are intentionally bundled into client JavaScript by Next.js.
+allowed_patterns:
+  - "NEXT_PUBLIC_*"
+
+# Server-side variables that are non-sensitive and safe to commit.
+# These are identifiers / slugs, not credentials.
+allowed_keys:
+  - FIREBASE_PROJECT_ID # Non-sensitive; also exposed via NEXT_PUBLIC_FIREBASE_PROJECT_ID
+  - FIREBASE_DATABASE_URL # Non-sensitive RTDB URL; also exposed as NEXT_PUBLIC_FIREBASE_DATABASE_URL when used client-side
+  - SENTRY_ORG # Sentry organisation slug — not a credential
+  - SENTRY_PROJECT # Sentry project slug — not a credential
+
+# Keys matching these patterns are always rejected, even if they match allowed_patterns.
+# Belt-and-suspenders: catches common secret naming conventions.
+denied_patterns:
+  - "*PRIVATE_KEY*"
+  - "*SECRET*"
+  - "*_TOKEN*"
+  - "*AUTH_TOKEN*"
+  - "FIREBASE_CLIENT_EMAIL"
+  - "SENTRY_AUTH_TOKEN"
+  - "SENTRY_DSN" # Server DSN is sensitive; use NEXT_PUBLIC_SENTRY_DSN for the public one

--- a/deployment/staging.yml
+++ b/deployment/staging.yml
@@ -1,0 +1,29 @@
+# Public environment variables for the staging environment.
+#
+# Only non-sensitive variables belong here. All keys are validated against
+# deployment/schema.yml — sensitive variables (private keys, auth tokens, DSNs)
+# will be rejected by the pre-commit hook and CI.
+#
+# Sensitive variables are managed directly in Vercel and are never committed.
+# Run `pnpm env:pull` to generate a local .env.local from Vercel's stored values.
+#
+# To update these values and sync them to Vercel: scripts/update-config.sh --env=staging
+
+environment: staging
+
+variables:
+  # Firebase Client SDK — safe to expose; access control is enforced by Firebase security rules
+  NEXT_PUBLIC_FIREBASE_API_KEY: ""
+  NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN: ""
+  NEXT_PUBLIC_FIREBASE_PROJECT_ID: ""
+  NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET: ""
+  NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID: ""
+  NEXT_PUBLIC_FIREBASE_APP_ID: ""
+  NEXT_PUBLIC_FIREBASE_DATABASE_URL: ""
+
+  # Firebase Admin SDK — project identifier only, not a credential
+  FIREBASE_PROJECT_ID: ""
+
+  # Sentry — slugs only, not credentials
+  SENTRY_ORG: ""
+  SENTRY_PROJECT: ""

--- a/package.json
+++ b/package.json
@@ -14,7 +14,10 @@
     "typecheck": "tsc --noEmit",
     "prepare": "husky",
     "storybook": "storybook dev -p 6006",
-    "build-storybook": "storybook build"
+    "build-storybook": "storybook build",
+    "env:pull": "scripts/generate-local-env.sh",
+    "env:validate": "node scripts/validate-config.mjs",
+    "secrets-check": "node scripts/secrets-check.mjs"
   },
   "dependencies": {
     "@base-ui/react": "^1.4.1",

--- a/scripts/generate-local-env.sh
+++ b/scripts/generate-local-env.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Generates .env.local in the project root by pulling from Vercel's stored
+# environment variables for the staging (preview) environment.
+#
+# Usage: scripts/generate-local-env.sh
+#
+# Requires: vercel CLI authenticated via `vercel login`
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# ── Prerequisites ─────────────────────────────────────────────────────────────
+
+if ! command -v vercel &>/dev/null; then
+  echo "ERROR: vercel CLI not found."
+  echo "Install it with: pnpm add -g vercel"
+  exit 1
+fi
+
+if ! vercel whoami &>/dev/null 2>&1; then
+  echo "ERROR: Not authenticated with Vercel."
+  echo "Run: vercel login"
+  exit 1
+fi
+
+# ── Pull ──────────────────────────────────────────────────────────────────────
+
+OUTPUT="$PROJECT_ROOT/.env.local"
+
+echo "Pulling staging environment variables from Vercel..."
+vercel env pull "$OUTPUT" --environment=preview --yes
+
+echo ""
+echo "Written to .env.local (gitignored — do not commit)."
+echo "Re-run this script after key rotation to refresh your local credentials."

--- a/scripts/rotate-keys.sh
+++ b/scripts/rotate-keys.sh
@@ -1,0 +1,269 @@
+#!/usr/bin/env bash
+# Rotates Firebase service account keys and Sentry auth tokens for one or both
+# environments. Updates Vercel with the new values, waits for a healthy
+# deployment, then decommissions the old credentials.
+#
+# Usage:
+#   scripts/rotate-keys.sh --env=staging
+#   scripts/rotate-keys.sh --env=production
+#   scripts/rotate-keys.sh                    # rotates both environments
+#   scripts/rotate-keys.sh --force-single     # allow single-environment repos
+#
+# All rotation credentials come from local user auth — nothing stored in Vercel:
+#   Firebase:  gcloud auth login
+#   Sentry:    sentry-cli login  (or SENTRY_AUTH_TOKEN in shell)
+#   Vercel:    vercel login
+#
+# Requires: gcloud, sentry-cli, vercel, jq
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+DEPLOYMENT_DIR="$PROJECT_ROOT/deployment"
+
+# ── Argument parsing ──────────────────────────────────────────────────────────
+
+ENV_TARGET=""
+FORCE_SINGLE=false
+
+for arg in "$@"; do
+  case "$arg" in
+    --env=*) ENV_TARGET="${arg#--env=}" ;;
+    --force-single) FORCE_SINGLE=true ;;
+    *) echo "ERROR: Unknown argument: $arg"; exit 1 ;;
+  esac
+done
+
+# ── Environment guard ─────────────────────────────────────────────────────────
+
+ENVIRONMENTS_FILE="$DEPLOYMENT_DIR/environments.yml"
+if [[ ! -f "$ENVIRONMENTS_FILE" ]]; then
+  echo "ERROR: deployment/environments.yml not found."
+  exit 1
+fi
+
+SINGLE_ENV=$(grep "^single_environment:" "$ENVIRONMENTS_FILE" | awk '{print $2}' || echo "false")
+mapfile -t CONFIGURED_ENVS < <(grep "^  - " "$ENVIRONMENTS_FILE" | awk '{print $2}')
+
+if [[ "${#CONFIGURED_ENVS[@]}" -lt 2 && "$SINGLE_ENV" != "true" && "$FORCE_SINGLE" != "true" ]]; then
+  echo "ERROR: Only one environment is configured but single_environment is not true."
+  echo "Set single_environment: true in deployment/environments.yml, or pass --force-single."
+  exit 1
+fi
+
+if [[ -n "$ENV_TARGET" ]]; then
+  ENVS_TO_ROTATE=("$ENV_TARGET")
+else
+  ENVS_TO_ROTATE=("${CONFIGURED_ENVS[@]}")
+fi
+
+for env in "${ENVS_TO_ROTATE[@]}"; do
+  if [[ ! -f "$DEPLOYMENT_DIR/$env.yml" ]]; then
+    echo "ERROR: deployment/$env.yml not found."
+    exit 1
+  fi
+done
+
+# ── Prerequisites ─────────────────────────────────────────────────────────────
+
+echo "Checking prerequisites..."
+
+for tool in gcloud sentry-cli vercel jq; do
+  if ! command -v "$tool" &>/dev/null; then
+    echo "ERROR: $tool not found."
+    case "$tool" in
+      gcloud)     echo "  Install: https://cloud.google.com/sdk/docs/install" ;;
+      sentry-cli) echo "  Install: curl -sL https://sentry.io/get-cli/ | bash" ;;
+      vercel)     echo "  Install: pnpm add -g vercel" ;;
+      jq)         echo "  Install: brew install jq" ;;
+    esac
+    exit 1
+  fi
+done
+
+if ! gcloud auth list --filter=status:ACTIVE --format="value(account)" 2>/dev/null | grep -q "@"; then
+  echo "ERROR: No active gcloud account. Run: gcloud auth login"
+  exit 1
+fi
+
+if ! vercel whoami &>/dev/null 2>&1; then
+  echo "ERROR: Not authenticated with Vercel. Run: vercel login"
+  exit 1
+fi
+
+# Sentry: accept either sentry-cli session or env var
+SENTRY_TOKEN="${SENTRY_AUTH_TOKEN:-}"
+if [[ -z "$SENTRY_TOKEN" ]]; then
+  SENTRY_TOKEN=$(grep "^token" ~/.sentryclirc 2>/dev/null | awk -F= '{print $2}' | tr -d ' ' || true)
+fi
+if [[ -z "$SENTRY_TOKEN" ]]; then
+  echo "ERROR: No Sentry credentials found."
+  echo "  Run: sentry-cli login"
+  echo "  Or:  export SENTRY_AUTH_TOKEN=<your-personal-token>"
+  exit 1
+fi
+
+echo "All prerequisites met."
+echo ""
+
+# ── Per-environment rotation ──────────────────────────────────────────────────
+
+rotate_environment() {
+  local env="$1"
+  local config_file="$DEPLOYMENT_DIR/$env.yml"
+
+  # Map env name to Vercel environment
+  local vercel_env
+  case "$env" in
+    staging)    vercel_env="preview" ;;
+    production) vercel_env="production" ;;
+    *) echo "ERROR: Unknown environment: $env"; exit 1 ;;
+  esac
+
+  echo "══════════════════════════════════════════"
+  echo " Rotating $env"
+  echo "══════════════════════════════════════════"
+
+  # Read project config
+  local project_id
+  project_id=$(grep "^  FIREBASE_PROJECT_ID:" "$config_file" | awk -F'"' '{print $2}' | tr -d ' ')
+  if [[ -z "$project_id" ]]; then
+    echo "ERROR: FIREBASE_PROJECT_ID not set in $config_file"
+    exit 1
+  fi
+
+  local sentry_org sentry_project
+  sentry_org=$(grep "^  SENTRY_ORG:" "$config_file" | awk -F'"' '{print $2}' | tr -d ' ')
+  sentry_project=$(grep "^  SENTRY_PROJECT:" "$config_file" | awk -F'"' '{print $2}' | tr -d ' ')
+
+  # Resolve service account email
+  local sa_email
+  sa_email=$(gcloud iam service-accounts list \
+    --project="$project_id" \
+    --filter="email:firebase-adminsdk" \
+    --format="value(email)" 2>/dev/null | head -1)
+  if [[ -z "$sa_email" ]]; then
+    echo "ERROR: Could not resolve Firebase service account email for project $project_id"
+    exit 1
+  fi
+
+  # Capture the current key IDs before creating new ones
+  echo "1. Capturing existing Firebase key IDs..."
+  mapfile -t OLD_KEY_IDS < <(gcloud iam service-accounts keys list \
+    --iam-account="$sa_email" \
+    --project="$project_id" \
+    --managed-by=user \
+    --format="value(name.basename())" 2>/dev/null)
+
+  # Create new Firebase key
+  echo "2. Creating new Firebase service account key..."
+  local key_file
+  key_file=$(mktemp)
+  trap 'rm -f "$key_file"' EXIT
+  gcloud iam service-accounts keys create "$key_file" \
+    --iam-account="$sa_email" \
+    --project="$project_id"
+
+  local new_client_email new_private_key
+  new_client_email=$(jq -r '.client_email' "$key_file")
+  # Vercel requires literal \n in the private key value
+  new_private_key=$(jq -r '.private_key' "$key_file" | awk '{printf "%s\\n", $0}' | sed 's/\\n$//')
+
+  # Create new Sentry token
+  echo "3. Creating new Sentry auth token..."
+  local new_sentry_token
+  if [[ -n "$sentry_org" && -n "$sentry_project" ]]; then
+    new_sentry_token=$(curl -sf \
+      -H "Authorization: Bearer $SENTRY_TOKEN" \
+      -H "Content-Type: application/json" \
+      -d "{\"scopes\":[\"project:releases\",\"project:read\",\"org:read\"]}" \
+      "https://sentry.io/api/0/api-tokens/" | jq -r '.token')
+    if [[ -z "$new_sentry_token" || "$new_sentry_token" == "null" ]]; then
+      echo "WARNING: Could not create Sentry token (check token scopes). Skipping Sentry rotation."
+      new_sentry_token=""
+    fi
+  else
+    echo "   (Sentry not configured for $env — skipping)"
+    new_sentry_token=""
+  fi
+
+  # Update Vercel
+  echo "4. Updating Vercel ($vercel_env)..."
+  for key in FIREBASE_CLIENT_EMAIL FIREBASE_PRIVATE_KEY; do
+    vercel env rm "$key" "$vercel_env" --yes 2>/dev/null || true
+  done
+  echo "$new_client_email" | vercel env add FIREBASE_CLIENT_EMAIL "$vercel_env"
+  echo "$new_private_key"  | vercel env add FIREBASE_PRIVATE_KEY "$vercel_env"
+
+  if [[ -n "$new_sentry_token" ]]; then
+    vercel env rm SENTRY_AUTH_TOKEN "$vercel_env" --yes 2>/dev/null || true
+    echo "$new_sentry_token" | vercel env add SENTRY_AUTH_TOKEN "$vercel_env"
+  fi
+
+  # Trigger redeploy and wait
+  echo "5. Triggering Vercel redeploy..."
+  local deploy_url
+  deploy_url=$(vercel deploy --target="$vercel_env" --yes 2>/dev/null | tail -1)
+  echo "   Deployed: $deploy_url"
+
+  echo "   Waiting for deployment to become healthy..."
+  local attempts=0
+  local max_attempts=30
+  while [[ $attempts -lt $max_attempts ]]; do
+    local state
+    state=$(vercel inspect "$deploy_url" --json 2>/dev/null | jq -r '.readyState // "BUILDING"')
+    if [[ "$state" == "READY" ]]; then
+      echo "   Deployment healthy."
+      break
+    elif [[ "$state" == "ERROR" || "$state" == "CANCELED" ]]; then
+      echo "ERROR: Deployment failed with state: $state"
+      echo "Old credentials are still active. Investigate before decommissioning."
+      exit 1
+    fi
+    attempts=$((attempts + 1))
+    echo "   State: $state — waiting 10s ($attempts/$max_attempts)..."
+    sleep 10
+  done
+
+  if [[ $attempts -ge $max_attempts ]]; then
+    echo "ERROR: Deployment did not become healthy within $(( max_attempts * 10 ))s."
+    echo "Old credentials are still active. Check Vercel dashboard before proceeding."
+    exit 1
+  fi
+
+  # Decommission old credentials (only after healthy deployment confirmed)
+  echo "6. Decommissioning old credentials..."
+  for old_key_id in "${OLD_KEY_IDS[@]}"; do
+    gcloud iam service-accounts keys delete "$old_key_id" \
+      --iam-account="$sa_email" \
+      --project="$project_id" \
+      --quiet 2>/dev/null && echo "   Deleted Firebase key: $old_key_id" || true
+  done
+
+  # Sentry: automatic revocation is skipped because listing all account tokens and
+  # excluding the new one would delete tokens belonging to other projects on the
+  # same Sentry user. Revoke the old token manually in the Sentry UI once the
+  # new deployment is confirmed healthy.
+  if [[ -n "$new_sentry_token" ]]; then
+    echo "   Sentry token updated. Manually revoke the previous token for this"
+    echo "   project/environment in the Sentry UI: https://sentry.io/settings/account/api/auth-tokens/"
+  fi
+
+  # Clean up key file
+  rm -f "$key_file"
+  trap - EXIT
+
+  echo ""
+  echo "$env rotation complete."
+  echo ""
+}
+
+# ── Run ───────────────────────────────────────────────────────────────────────
+
+for env in "${ENVS_TO_ROTATE[@]}"; do
+  rotate_environment "$env"
+done
+
+echo "All rotations complete."
+echo "Run 'pnpm env:pull' to refresh your local .env.local with the new staging credentials."

--- a/scripts/rotate-keys.sh
+++ b/scripts/rotate-keys.sh
@@ -126,16 +126,20 @@ rotate_environment() {
   echo "══════════════════════════════════════════"
 
   # Read project config
+  # Extract value after the colon and strip optional surrounding quotes (both ' and ").
+  # This handles both quoted values written by update-config.sh and manually-edited
+  # unquoted values, which are equally valid YAML.
   local project_id
-  project_id=$(grep "^  FIREBASE_PROJECT_ID:" "$config_file" | awk -F'"' '{print $2}' | tr -d ' ')
+  project_id=$(grep "^  FIREBASE_PROJECT_ID:" "$config_file" | sed 's/.*: *//' | tr -d "\"' ")
   if [[ -z "$project_id" ]]; then
-    echo "ERROR: FIREBASE_PROJECT_ID not set in $config_file"
+    echo "ERROR: FIREBASE_PROJECT_ID is empty or not set in $config_file"
+    echo "  Run: scripts/update-config.sh --env=$env --firebase-config=/path/to/config.json"
     exit 1
   fi
 
   local sentry_org sentry_project
-  sentry_org=$(grep "^  SENTRY_ORG:" "$config_file" | awk -F'"' '{print $2}' | tr -d ' ')
-  sentry_project=$(grep "^  SENTRY_PROJECT:" "$config_file" | awk -F'"' '{print $2}' | tr -d ' ')
+  sentry_org=$(grep "^  SENTRY_ORG:" "$config_file" | sed 's/.*: *//' | tr -d "\"' ")
+  sentry_project=$(grep "^  SENTRY_PROJECT:" "$config_file" | sed 's/.*: *//' | tr -d "\"' ")
 
   # Resolve service account email
   local sa_email

--- a/scripts/secrets-check.mjs
+++ b/scripts/secrets-check.mjs
@@ -1,0 +1,49 @@
+#!/usr/bin/env node
+/**
+ * Pre-commit secrets check. Runs two guards in sequence:
+ *   1. Validates deployment config files against deployment/schema.yml
+ *   2. Scans staged files for secrets via gitleaks (if installed)
+ *
+ * Designed to be invoked via `pnpm run secrets-check`.
+ * Intended to be called from .husky/pre-commit alongside lint-staged.
+ */
+
+import { execSync, spawnSync } from "child_process";
+import { existsSync } from "fs";
+import { join, dirname } from "path";
+import { fileURLToPath } from "url";
+
+const root = join(dirname(fileURLToPath(import.meta.url)), "..");
+
+// ── 1. Deployment config validation ──────────────────────────────────────────
+
+const validateScript = join(root, "scripts", "validate-config.mjs");
+if (existsSync(validateScript)) {
+  try {
+    execSync(`node "${validateScript}"`, { stdio: "inherit", cwd: root });
+  } catch {
+    process.exit(1);
+  }
+}
+
+// ── 2. Gitleaks secret scan ───────────────────────────────────────────────────
+
+const gitleaks = spawnSync("which", ["gitleaks"], { encoding: "utf8" });
+if (gitleaks.status !== 0) {
+  console.warn(
+    "\nWARNING: gitleaks not installed — secret scanning skipped.\n" +
+      "  Install with: brew install gitleaks\n" +
+      "  Secrets will still be caught by CI, but local detection is strongly recommended.\n",
+  );
+  process.exit(0);
+}
+
+const result = spawnSync(
+  "gitleaks",
+  ["protect", "--staged", "--config", ".gitleaks.toml", "--redact"],
+  { stdio: "inherit", cwd: root },
+);
+
+if (result.status !== 0) {
+  process.exit(result.status ?? 1);
+}

--- a/scripts/update-config.sh
+++ b/scripts/update-config.sh
@@ -1,0 +1,167 @@
+#!/usr/bin/env bash
+# Updates a public environment config file and syncs all its variables to Vercel.
+#
+# Usage:
+#   scripts/update-config.sh --env=staging KEY=value [KEY=value ...]
+#   scripts/update-config.sh --env=production --firebase-config=/path/to/config.json
+#
+# The --firebase-config flag accepts the path to a JSON file containing the
+# firebaseConfig object exported from the Firebase console. It extracts and maps
+# the relevant NEXT_PUBLIC_FIREBASE_* keys automatically.
+#
+# Sensitive values must NEVER be passed as KEY=value arguments — they will appear
+# in shell history and ps output. Use `vercel env add` directly for secrets.
+#
+# Requires: node, vercel CLI authenticated via `vercel login`
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+DEPLOYMENT_DIR="$PROJECT_ROOT/deployment"
+
+# ── Argument parsing ──────────────────────────────────────────────────────────
+
+ENV_NAME=""
+FIREBASE_CONFIG_FILE=""
+declare -a KEY_VALUE_PAIRS=()
+
+for arg in "$@"; do
+  case "$arg" in
+    --env=*) ENV_NAME="${arg#--env=}" ;;
+    --firebase-config=*) FIREBASE_CONFIG_FILE="${arg#--firebase-config=}" ;;
+    *=*) KEY_VALUE_PAIRS+=("$arg") ;;
+    *) echo "ERROR: Unknown argument: $arg"; exit 1 ;;
+  esac
+done
+
+if [[ -z "$ENV_NAME" ]]; then
+  echo "ERROR: --env=<staging|production> is required."
+  exit 1
+fi
+
+CONFIG_FILE="$DEPLOYMENT_DIR/$ENV_NAME.yml"
+if [[ ! -f "$CONFIG_FILE" ]]; then
+  echo "ERROR: $CONFIG_FILE not found. Create it first."
+  exit 1
+fi
+
+# ── Prerequisites ─────────────────────────────────────────────────────────────
+
+if ! command -v vercel &>/dev/null; then
+  echo "ERROR: vercel CLI not found. Install with: pnpm add -g vercel"
+  exit 1
+fi
+
+if ! vercel whoami &>/dev/null 2>&1; then
+  echo "ERROR: Not authenticated with Vercel. Run: vercel login"
+  exit 1
+fi
+
+# ── Firebase config extraction ────────────────────────────────────────────────
+
+if [[ -n "$FIREBASE_CONFIG_FILE" ]]; then
+  if [[ ! -f "$FIREBASE_CONFIG_FILE" ]]; then
+    echo "ERROR: Firebase config file not found: $FIREBASE_CONFIG_FILE"
+    exit 1
+  fi
+  echo "Extracting Firebase client config from $FIREBASE_CONFIG_FILE..."
+  while IFS="=" read -r key value; do
+    KEY_VALUE_PAIRS+=("$key=$value")
+  done < <(FIREBASE_CONFIG_PATH="$FIREBASE_CONFIG_FILE" node -e "
+    const cfg = JSON.parse(require('fs').readFileSync(process.env.FIREBASE_CONFIG_PATH, 'utf8'));
+    const map = {
+      apiKey: 'NEXT_PUBLIC_FIREBASE_API_KEY',
+      authDomain: 'NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN',
+      projectId: 'NEXT_PUBLIC_FIREBASE_PROJECT_ID',
+      storageBucket: 'NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET',
+      messagingSenderId: 'NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID',
+      appId: 'NEXT_PUBLIC_FIREBASE_APP_ID',
+      databaseURL: 'NEXT_PUBLIC_FIREBASE_DATABASE_URL',
+    };
+    const src = cfg.firebaseConfig ?? cfg;
+    for (const [k, v] of Object.entries(src)) {
+      if (map[k]) process.stdout.write(map[k] + '=' + v + '\n');
+    }
+  ")
+fi
+
+if [[ ${#KEY_VALUE_PAIRS[@]} -eq 0 ]]; then
+  echo "ERROR: No key=value pairs provided and no --firebase-config specified."
+  exit 1
+fi
+
+# ── Update YAML in place ──────────────────────────────────────────────────────
+
+echo "Updating $CONFIG_FILE..."
+
+for pair in "${KEY_VALUE_PAIRS[@]}"; do
+  KEY="${pair%%=*}"
+  VALUE="${pair#*=}"
+
+  # Update existing key or insert within the variables: block.
+  # KEY and VALUE are passed via process.argv to avoid shell injection.
+  action=$(node - "$CONFIG_FILE" "$KEY" "$VALUE" <<'NODE'
+const fs = require('fs');
+const [, , configFile, key, value] = process.argv;
+const escapeRegex = s => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+const content = fs.readFileSync(configFile, 'utf8');
+const lines = content.split('\n');
+
+const variablesStart = lines.findIndex(l => /^variables:\s*$/.test(l));
+if (variablesStart === -1) {
+  process.stderr.write(`ERROR: No variables: block found in ${configFile}\n`);
+  process.exit(1);
+}
+
+let variablesEnd = lines.length;
+for (let i = variablesStart + 1; i < lines.length; i++) {
+  if (/^\S/.test(lines[i]) && lines[i].trim() !== '') { variablesEnd = i; break; }
+}
+
+const renderedLine = `  ${key}: ${JSON.stringify(value)}`;
+const keyPat = new RegExp(`^  ${escapeRegex(key)}:.*$`);
+let updated = false;
+for (let i = variablesStart + 1; i < variablesEnd; i++) {
+  if (keyPat.test(lines[i])) { lines[i] = renderedLine; updated = true; break; }
+}
+if (!updated) lines.splice(variablesEnd, 0, renderedLine);
+
+let out = lines.join('\n');
+if (content.endsWith('\n') && !out.endsWith('\n')) out += '\n';
+fs.writeFileSync(configFile, out);
+process.stdout.write(updated ? 'Updated' : 'Added');
+NODE
+  )
+  echo "  $action $KEY"
+done
+
+# ── Validate ──────────────────────────────────────────────────────────────────
+
+echo ""
+echo "Validating against schema..."
+node "$SCRIPT_DIR/validate-config.mjs" --env="$ENV_NAME"
+
+# ── Sync to Vercel ────────────────────────────────────────────────────────────
+
+# Map environment name to Vercel environment target
+case "$ENV_NAME" in
+  staging)    VERCEL_ENV="preview" ;;
+  production) VERCEL_ENV="production" ;;
+  *) echo "ERROR: Unknown environment: $ENV_NAME"; exit 1 ;;
+esac
+
+echo ""
+echo "Syncing to Vercel ($VERCEL_ENV)..."
+
+for pair in "${KEY_VALUE_PAIRS[@]}"; do
+  KEY="${pair%%=*}"
+  VALUE="${pair#*=}"
+  # Remove existing value then add new one (vercel env add errors if key exists)
+  vercel env rm "$KEY" "$VERCEL_ENV" --yes 2>/dev/null || true
+  echo "$VALUE" | vercel env add "$KEY" "$VERCEL_ENV"
+  echo "  Synced $KEY"
+done
+
+echo ""
+echo "Done. Run 'pnpm env:pull' to refresh your local .env.local."

--- a/scripts/validate-config.mjs
+++ b/scripts/validate-config.mjs
@@ -1,0 +1,181 @@
+#!/usr/bin/env node
+/**
+ * Validates deployment config files against deployment/schema.yml.
+ *
+ * Reads each environment listed in deployment/environments.yml, loads the
+ * corresponding deployment/{env}.yml, and checks every key against:
+ *   1. denied_patterns  — reject immediately (belt-and-suspenders)
+ *   2. allowed_patterns — accept if matched
+ *   3. allowed_keys     — accept if listed explicitly
+ *
+ * Exits 0 if all configs are valid, 1 if any violations are found.
+ * Accepts optional --env=<name> to validate a single environment.
+ */
+
+import { readFileSync, existsSync } from "fs";
+import { join, dirname } from "path";
+import { fileURLToPath } from "url";
+
+const root = join(dirname(fileURLToPath(import.meta.url)), "..");
+const deploymentDir = join(root, "deployment");
+
+function parseYamlSimple(content) {
+  // Minimal YAML parser for the constrained flat-key: value format used here.
+  // Does not handle anchors, multiline values, or nested structures.
+  const result = {};
+  for (const rawLine of content.split("\n")) {
+    const line = rawLine.replace(/#.*$/, "").trim();
+    if (!line) continue;
+    const colonIndex = line.indexOf(":");
+    if (colonIndex === -1) continue;
+    const key = line.slice(0, colonIndex).trim();
+    const value = line
+      .slice(colonIndex + 1)
+      .trim()
+      .replace(/^["']|["']$/g, "");
+    if (key) result[key] = value;
+  }
+  return result;
+}
+
+function parseYamlList(content, listKey) {
+  const lines = content.split("\n");
+  const items = [];
+  let inList = false;
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (trimmed.startsWith(`${listKey}:`)) {
+      inList = true;
+      continue;
+    }
+    if (inList) {
+      if (trimmed.startsWith("- ")) {
+        items.push(
+          trimmed
+            .slice(2)
+            .replace(/#.*$/, "")
+            .replace(/^["']|["']$/g, "")
+            .trim(),
+        );
+      } else if (trimmed && !trimmed.startsWith("#")) {
+        inList = false;
+      }
+    }
+  }
+  return items;
+}
+
+function globMatch(pattern, key) {
+  const regex = new RegExp(
+    "^" +
+      pattern.replace(/[.+^${}()|[\]\\]/g, "\\$&").replace(/\*/g, ".*") +
+      "$",
+  );
+  return regex.test(key);
+}
+
+function loadSchema() {
+  const content = readFileSync(join(deploymentDir, "schema.yml"), "utf8");
+  return {
+    allowedPatterns: parseYamlList(content, "allowed_patterns"),
+    allowedKeys: parseYamlList(content, "allowed_keys"),
+    deniedPatterns: parseYamlList(content, "denied_patterns"),
+  };
+}
+
+function loadEnvironments() {
+  const content = readFileSync(join(deploymentDir, "environments.yml"), "utf8");
+  const envs = parseYamlList(content, "environments");
+  const parsed = parseYamlSimple(content);
+  const singleEnv = parsed["single_environment"] === "true";
+  return { environments: envs, singleEnvironment: singleEnv };
+}
+
+function validateConfig(envName, schema) {
+  const configPath = join(deploymentDir, `${envName}.yml`);
+  if (!existsSync(configPath)) {
+    return [`deployment/${envName}.yml not found`];
+  }
+
+  const content = readFileSync(configPath, "utf8");
+  const inVariablesSection = [];
+  let inVars = false;
+  for (const rawLine of content.split("\n")) {
+    const line = rawLine.replace(/#.*$/, "");
+    const trimmed = line.trim();
+    if (trimmed === "variables:") {
+      inVars = true;
+      continue;
+    }
+    if (inVars && trimmed && !trimmed.startsWith("#")) {
+      // A non-indented line signals a new top-level section — stop collecting
+      if (!line.startsWith(" ")) {
+        inVars = false;
+        continue;
+      }
+      const colonIndex = trimmed.indexOf(":");
+      if (colonIndex !== -1) {
+        const key = trimmed.slice(0, colonIndex).trim();
+        // Skip commented-out example lines (original line starts with whitespace + #)
+        if (!rawLine.trim().startsWith("#") && key) {
+          inVariablesSection.push(key);
+        }
+      }
+    }
+  }
+
+  const errors = [];
+  for (const key of inVariablesSection) {
+    const isDenied = schema.deniedPatterns.some((p) => globMatch(p, key));
+    if (isDenied) {
+      errors.push(
+        `  DENIED   ${key}  (matches a denied_pattern in schema.yml)`,
+      );
+      continue;
+    }
+    const isAllowed =
+      schema.allowedPatterns.some((p) => globMatch(p, key)) ||
+      schema.allowedKeys.includes(key);
+    if (!isAllowed) {
+      errors.push(
+        `  REJECTED ${key}  (not in allowed_patterns or allowed_keys in schema.yml)`,
+      );
+    }
+  }
+  return errors;
+}
+
+const args = process.argv.slice(2);
+const envArg = args.find((a) => a.startsWith("--env="))?.slice(6);
+
+const { environments, singleEnvironment } = loadEnvironments();
+const schema = loadSchema();
+
+const toValidate = envArg ? [envArg] : environments;
+
+if (!singleEnvironment && environments.length < 2 && !envArg) {
+  console.error(
+    "ERROR: environments.yml lists fewer than 2 environments but single_environment is not true.\n" +
+      "Set single_environment: true if this project intentionally uses one environment.",
+  );
+  process.exit(1);
+}
+
+let anyErrors = false;
+for (const env of toValidate) {
+  const errors = validateConfig(env, schema);
+  if (errors.length > 0) {
+    console.error(`\ndeployment/${env}.yml — ${errors.length} violation(s):`);
+    for (const e of errors) console.error(e);
+    anyErrors = true;
+  } else {
+    console.log(`deployment/${env}.yml — OK`);
+  }
+}
+
+if (anyErrors) {
+  console.error(
+    "\nFix the violations above or update deployment/schema.yml to allow these keys.",
+  );
+  process.exit(1);
+}


### PR DESCRIPTION
Syncs the deploy config validation, secret scanning, and key rotation infrastructure from [firebase-nextjs-template PR #43](https://github.com/rmartz/firebase-nextjs-template/pull/43).

**What's included:**
- `deployment/{staging,production}.yml` — committed public env vars (Firebase client SDK keys, RTDB URL, project IDs). Placeholder values; populate with `scripts/update-config.sh`.
- `deployment/schema.yml` — allow/deny patterns that gate what can go in deployment files (blocks private keys, auth tokens, DSNs)
- `scripts/validate-config.mjs` — validates configs against schema; runs in pre-commit and CI
- `scripts/secrets-check.mjs` — pre-commit orchestrator: config validation + gitleaks scan
- `scripts/generate-local-env.sh` — `pnpm env:pull`: pulls `.env.local` from Vercel staging
- `scripts/update-config.sh` — updates a deployment YAML and syncs values to Vercel (accepts `--firebase-config` to auto-extract from Firebase console JSON)
- `scripts/rotate-keys.sh` — zero-downtime Firebase/Sentry/Vercel credential rotation
- `.gitleaks.toml` — Firebase private key, admin JSON, and Vercel token detection rules
- `.github/workflows/secret-scan.yml` — CI: gitleaks scan on PRs/main + config validation
- `.husky/pre-commit` — now runs `pnpm secrets-check` after `lint-staged`
- `AGENTS.md` — deployment config section; several template improvements (`.spec.ts` clarification, dynamic import exception for Sentry, enum barrel export note, "three similar lines" note)

**Note:** `deployment/*.yml` values are empty placeholders. Once you have Firebase project IDs and Sentry slugs, run `scripts/update-config.sh` to populate them.

---
*Created by Claude Sonnet 4.6*