### PR TITLE
chore: approve pnpm build scripts for transitive dependencies

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,6 @@
 onlyBuiltDependencies:
+  - "@firebase/util"
+  - esbuild
+  - msw
+  - protobufjs
   - vercel-deploy-scripts


### PR DESCRIPTION
Silences the `pnpm install` warning about unapproved build scripts by adding the flagged transitive dependencies to the `onlyBuiltDependencies` allowlist in `pnpm-workspace.yaml`.

Packages added: `@firebase/util`, `esbuild`, `msw`, `protobufjs`. All are well-known packages with legitimate build scripts (platform binary selection for esbuild, postinstall codegen for msw/protobufjs/firebase).

---
*Created by Claude Sonnet 4.6*