### PR TITLE
ci: split out Storybook browser tests and cache Playwright browser

### DIFF
--- a/.github/workflows/ci-actions.yml
+++ b/.github/workflows/ci-actions.yml
@@ -26,14 +26,38 @@ jobs:
       - uses: ./.github/actions/setup
       - run: pnpm format:check
 
-  test:
-    name: Test
+  vite-test:
+    name: Vite Tests
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup
-      - run: pnpm exec playwright install --with-deps chromium
-      - run: pnpm test
+      - run: pnpm test:unit
+
+  storybook-test:
+    name: Storybook Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/setup
+      - name: Resolve Playwright version
+        id: playwright
+        shell: bash
+        run: echo "version=$(pnpm exec playwright --version | sed 's/^Version //')" >> "$GITHUB_OUTPUT"
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ steps.playwright.outputs.version }}
+      # Browser binary (~170 MiB) is cacheable; skip the download on a cache hit.
+      - name: Install Playwright browser
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        run: pnpm exec playwright install chromium
+      # apt system libraries are not cacheable, so always (re)install them.
+      - name: Install Playwright system dependencies
+        run: pnpm exec playwright install-deps chromium
+      - run: pnpm test:storybook
 
   build:
     name: Build

--- a/.github/workflows/ci-actions.yml
+++ b/.github/workflows/ci-actions.yml
@@ -26,8 +26,8 @@ jobs:
       - uses: ./.github/actions/setup
       - run: pnpm format:check
 
-  vite-test:
-    name: Vite Tests
+  test:
+    name: Test
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/package.json
+++ b/package.json
@@ -8,6 +8,8 @@
     "build": "next build",
     "start": "next start",
     "test": "vitest run",
+    "test:unit": "vitest run --project node --project components",
+    "test:storybook": "vitest run --project storybook",
     "lint": "eslint --max-warnings 0 .",
     "format": "prettier --write .",
     "format:check": "prettier --check .",


### PR DESCRIPTION
## Purpose

The single `Test` job ran the entire Vitest suite — including the Chromium-backed Storybook browser project — behind a `playwright install --with-deps chromium` step on every run, with no caching of the browser binary. This splits the browser tests into their own job and caches the Playwright download so the fast, non-browser tests aren't gated by the browser setup.

> **Note:** the original ">10 minute" symptom was actually a Node 24.16+ `extract-zip` regression hanging `playwright install` after the download finished — fixed separately by the toolchain pins in #117 (merged). On healthy runners the browser download+install is only ~9s, so the caching win here is modest; the larger benefit is structural — the unit tests no longer wait on the browser job.

## Changes

- **Split the suite into two concurrent jobs.** `Test` runs the non-browser Vitest projects (`node` + `components`) via `pnpm test:unit`; `Storybook Tests` runs the Chromium `storybook` project via `pnpm test:storybook`. `Test` keeps the established check name; `Storybook Tests` is the broken-out special case.
- **Cache the Playwright browser.** `actions/cache` keyed on the resolved Playwright version caches `~/.cache/ms-playwright`; on a cache hit the browser-install step is skipped. apt system libraries aren't cacheable, so `playwright install-deps chromium` still runs each time.
- Added `test:unit` / `test:storybook` scripts (`test` still runs all three projects locally).

## Measured results (CI)

| Job | Before (single `Test`) | After |
| --- | --- | --- |
| Non-browser tests | — (ran together, gated by browser install) | **`Test` 25–30s**, concurrent |
| Storybook (Chromium) | — | **54s cold → 46s warm** (cache hit skips the ~9s browser install) |

68 non-browser tests + 31 Storybook tests, all green.

---
*Created by Claude Opus 4.8*
