### PR TITLE
ci: pin pnpm and Node versions in CI setup action

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -13,7 +13,11 @@ runs:
         version: 10.30.3
     - uses: actions/setup-node@v6
       with:
-        node-version: 24.x
+        # Pin the exact Node version. The floating "24.x" tag resolves to
+        # >=24.16.0 (currently 24.17.0), which carries an extract-zip/yauzl
+        # regression that hangs `playwright install` indefinitely right after
+        # the browser download reaches 100%. 24.15.0 is the last good 24.x.
+        node-version: 24.15.0
         cache: "pnpm"
     - run: git config --global url."https://x-access-token:${{ github.token }}@github.com/".insteadOf "git@github.com:"
       shell: bash

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -6,7 +6,11 @@ runs:
   steps:
     - uses: pnpm/action-setup@v5
       with:
-        version: 10
+        # Pin the exact pnpm version so CI matches local installs. The floating
+        # "10" tag resolves to the latest 10.x (10.34.x), which enforces
+        # ERR_PNPM_GIT_DEP_PREPARE_NOT_ALLOWED for the git-hosted
+        # vercel-deploy-scripts dependency and fails `install --frozen-lockfile`.
+        version: 10.30.3
     - uses: actions/setup-node@v6
       with:
         node-version: 24.x


### PR DESCRIPTION
## Purpose

CI was fully red on **every** job on `main`, and the `Test` job additionally hung for hours. Both failures trace to the shared `./.github/actions/setup` action requesting **floating tool versions** that drifted into broken releases. This pins them to known-good versions.

## Two floating-version regressions

**1. pnpm — `version: 10` → 10.34.x (install fails).**
Newer pnpm 10.x enforces `ERR_PNPM_GIT_DEP_PREPARE_NOT_ALLOWED`: a git-hosted dependency that runs a `prepare`/build step must be allowlisted by its **fully-resolved git URL**, not the bare package name. Our `vercel-deploy-scripts` entry in `onlyBuiltDependencies` uses the bare name, so `pnpm install --frozen-lockfile` aborts on a clean store. (A warm local store skipped the prepare, hiding it locally.) → Pinned to **10.30.3** (the version run locally).

**2. Node — `node-version: 24.x` → 24.17.0 (Playwright install hangs).**
Node ≥24.16.0 carries an `extract-zip`/`yauzl` regression: `playwright install` downloads Chrome-for-Testing to 100%, then hangs **indefinitely** during extraction — the `Test` job ran ~3.5h until cancelled. → Pinned to **24.15.0**, the last good 24.x. Ref: microsoft/playwright#41000.

## Fix

Pin both exact versions in the setup action. Pinning (rather than chasing the floating tags or allowlisting a brittle SHA-pinned URL) makes CI reproducibly match a known-good local toolchain — the same drift these floating tags caused will not recur silently.

## Verification

- pnpm: reproduced against a fresh store locally — `10.34.3` → `ERR_PNPM_GIT_DEP_PREPARE_NOT_ALLOWED`; `10.30.3` → clean install.
- Node: the hang reproduced in CI on `v24.17.0` (download → 100% → 3.5h hang → cancelled); 24.15.0 is documented as the last unaffected 24.x.

---
*Created by Claude Opus 4.8*
