### PR TITLE
ci: add typecheck CI job

### DIFF
--- a/.github/workflows/ci-actions.yml
+++ b/.github/workflows/ci-actions.yml
@@ -26,6 +26,14 @@ jobs:
       - uses: ./.github/actions/setup
       - run: pnpm format:check
 
+  typecheck:
+    name: Typecheck
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/setup
+      - run: pnpm typecheck
+
   test:
     name: Test
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Purpose

Adds a dedicated `Typecheck` job to the CI workflow so TypeScript type errors are caught in CI, closing a gap where `lint`, `format`, `test`, `storybook-test`, and `build` ran but `tsc --noEmit` did not.

## Technical considerations

- The job mirrors the existing `lint`/`format` jobs: checkout, `./.github/actions/setup`, then `pnpm typecheck`.
- This is a CI-tightening change. `pnpm typecheck` already passes cleanly on `main`, so no code fixes were required alongside it.

---
*Created by Claude Opus 4.8*
