### PR TITLE
ci: enforce full major.minor.patch package.json pins

### DIFF
--- a/.github/workflows/check-package-pins.yml
+++ b/.github/workflows/check-package-pins.yml
@@ -1,0 +1,27 @@
+name: Package Pins
+
+# Only runs on PRs that touch dependency manifests or the lockfile — there is
+# nothing to check on a PR that doesn't alter dependencies.
+on:
+  pull_request:
+    paths:
+      - "package.json"
+      - "**/package.json"
+      - "pnpm-lock.yaml"
+
+permissions:
+  contents: read
+
+jobs:
+  check-pins:
+    name: Package version pins
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - uses: actions/checkout@v7
+      # The check reads package.json with Node built-ins only — no pnpm install
+      # needed, so use a lightweight Node setup instead of the project setup.
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24.15.0
+      - run: node scripts/check-package-pins.mjs

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,6 +7,7 @@
 ## Dependencies
 
 - **Every dependency pin in `package.json` must specify the full `major.minor.patch` version**, even with a range annotation — e.g. `"prettier": "^3.8.3"`, never `"prettier": "^3"` or `"prettier": "^3.8"`. Pin to the version currently resolved in `pnpm-lock.yaml`, preserving any `^`/`~` annotation. This keeps Dependabot version bumps visible in the `package.json` diff: with an abbreviated pin like `^3`, a minor/patch bump (which can still require code changes — e.g. a Prettier reformat) changes only `pnpm-lock.yaml` and is easy to miss in review. A full pin forces every bump to update `package.json` too.
+- This is enforced in CI by the `Package Pins` workflow (`pnpm pins:check`), which runs on any PR that touches `package.json` or `pnpm-lock.yaml` and fails on a non-full pin.
 
 ## Common Commands
 
@@ -22,6 +23,7 @@ pnpm typecheck        # Type check
 pnpm storybook        # Start Storybook dev server (port 6006)
 pnpm build-storybook  # Build static Storybook
 pnpm env:validate     # Validate deployment config files against schema
+pnpm pins:check       # Verify package.json pins specify full versions
 ```
 
 ## Worktree Setup

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "prepare": "husky",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",
-    "env:validate": "node scripts/validate-config.mjs"
+    "env:validate": "node scripts/validate-config.mjs",
+    "pins:check": "node scripts/check-package-pins.mjs"
   },
   "dependencies": {
     "@base-ui/react": "^1.6.0",

--- a/scripts/check-package-pins.mjs
+++ b/scripts/check-package-pins.mjs
@@ -1,0 +1,104 @@
+#!/usr/bin/env node
+/**
+ * Enforces that every registry dependency in every package.json specifies a
+ * full [major].[minor].[patch] base version (the `^`/`~` operator is kept).
+ *
+ * A bare-major range like "^3" hides which version is actually installed, so a
+ * lock-only Dependabot bump can silently change behavior with no package.json
+ * diff (see #114, where a "^3" prettier pin reformatted the codebase via a
+ * pnpm-lock.yaml-only update). Requiring a full base makes every bump show up
+ * as an explicit, reviewable package.json change.
+ *
+ * For each dependency the rule is: strip a single leading `^` or `~`, then the
+ * remainder must match \d+\.\d+\.\d+ (optionally with a -prerelease / +build
+ * suffix). Non-registry specifiers (workspace:, catalog:, link:, file:, npm:
+ * aliases, git/github/URL deps) are skipped — they don't resolve from the
+ * registry by version range.
+ *
+ * Exits 0 if all pins are compliant, 1 if any violations are found.
+ */
+
+import { readFileSync, readdirSync } from "fs";
+import { join, dirname, relative } from "path";
+import { fileURLToPath } from "url";
+
+const root = join(dirname(fileURLToPath(import.meta.url)), "..");
+
+// Directories that never hold first-party manifests we control.
+const IGNORED_DIRS = new Set([
+  "node_modules",
+  ".git",
+  ".git-worktrees",
+  ".next",
+  "dist",
+  "storybook-static",
+]);
+
+// Dependency sections to enforce. peerDependencies are intentionally excluded:
+// they legitimately use open ranges (e.g. "*") to express compatibility.
+const SECTIONS = ["dependencies", "devDependencies", "optionalDependencies"];
+
+// A specifier that does not resolve from the registry by semver range.
+const NON_REGISTRY =
+  /^(workspace:|catalog:|link:|file:|portal:|npm:|git\+|git:|github:|https?:)/;
+
+// Full base after stripping an optional ^ or ~: major.minor.patch (+suffix).
+const FULL_BASE = /^[\^~]?\d+\.\d+\.\d+([-+].+)?$/;
+
+function findManifests(dir) {
+  const found = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    if (entry.isDirectory()) {
+      if (!IGNORED_DIRS.has(entry.name)) {
+        found.push(...findManifests(join(dir, entry.name)));
+      }
+    } else if (entry.name === "package.json") {
+      found.push(join(dir, entry.name));
+    }
+  }
+  return found;
+}
+
+function isNonRegistry(range) {
+  // Catch protocol-prefixed specifiers plus github "owner/repo" shorthand and
+  // any URL — none of which a plain semver range ever contains.
+  return (
+    NON_REGISTRY.test(range) || range.includes("/") || range.includes("://")
+  );
+}
+
+function checkManifest(manifestPath) {
+  const pkg = JSON.parse(readFileSync(manifestPath, "utf8"));
+  const rel = relative(root, manifestPath) || "package.json";
+  const violations = [];
+  for (const section of SECTIONS) {
+    const deps = pkg[section];
+    if (!deps) continue;
+    for (const [name, range] of Object.entries(deps)) {
+      if (typeof range !== "string" || isNonRegistry(range)) continue;
+      if (!FULL_BASE.test(range)) {
+        violations.push(`  ${rel}  ${name}  "${range}"`);
+      }
+    }
+  }
+  return violations;
+}
+
+const manifests = findManifests(root);
+const violations = manifests.flatMap(checkManifest);
+
+if (violations.length > 0) {
+  console.error(
+    `Found ${violations.length} dependency pin(s) without a full [major].[minor].[patch] base:\n`,
+  );
+  for (const v of violations) console.error(v);
+  console.error(
+    "\nExpand each range to its full installed version (keep the ^/~ operator), " +
+      'e.g. "^3" -> "^3.9.4". Read the installed version from pnpm-lock.yaml.',
+  );
+  process.exit(1);
+}
+
+console.log(
+  `All dependency pins specify a full version (${manifests.length} package.json checked).`,
+);


### PR DESCRIPTION
## Purpose

The full-version pinning rule added in [#124](https://github.com/rmartz/trip-split/pull/124) is documented but unenforced — a future edit or new package could reintroduce a bare-major pin like `"prettier": "^3"`, and (as in [#114](https://github.com/rmartz/trip-split/pull/114)) it would only surface as a confusing red formatting check on a lock-only Dependabot bump. This adds a CI ratchet to keep the manifest compliant. Implements the check proposed in [rmartz/ai-tools#63](https://github.com/rmartz/ai-tools/issues/63).

## Changes

- **`scripts/check-package-pins.mjs`** — walks every `package.json` and fails if any registry dependency's range base isn't a full `major.minor.patch` (the `^`/`~` operator is kept). Non-registry specifiers (`workspace:`, `catalog:`, `link:`, `file:`, `npm:` aliases, git/github/URL deps) are skipped. `peerDependencies` are excluded since they legitimately use open ranges.
- **`package.json`** — adds `pnpm pins:check`.
- **`.github/workflows/check-package-pins.yml`** — a `Package Pins` workflow that runs the check **only on PRs that touch `package.json` or `pnpm-lock.yaml`** (path-filtered, per the request). Uses a lightweight Node setup — the check needs no dependency install.
- **AGENTS.md** — documents the command and that CI enforces the rule.

## Stacked PR

Based on [#124](https://github.com/rmartz/trip-split/pull/124) because the check would fail against `main`'s current loose pins; on top of #124's compliant manifest it passes. Targets `chore/pin-package-versions`; GitHub will retarget it to `main` once #124 merges.

---
*Created by Claude Opus 4.8*
